### PR TITLE
Add support for other resolutions

### DIFF
--- a/src/main/java/highlight/NodeHighlight.java
+++ b/src/main/java/highlight/NodeHighlight.java
@@ -20,6 +20,9 @@ public class NodeHighlight implements Renderable {
     private final static Texture COLOR = new Texture("images/highlight/color.png");
     private final static Texture X = new Texture("images/highlight/map_x.png");
 
+    public static final float HIGHLIGHT_WIDTH = 100.0f * Settings.scale;
+    public static final float HIGHLIGHT_HEIGHT = 100.0f * Settings.scale;
+
     public NodeHighlight(Hitbox hb, int floor, Color color) {
         this.color = color;
         this.floor = floor;
@@ -66,13 +69,13 @@ public class NodeHighlight implements Renderable {
             return;
 
         sb.setColor(Color.WHITE);
-        sb.draw(BACKGROUND, hb.x - 18.0f * Settings.scale, hb.y - 18.0f * Settings.scale);
+        sb.draw(BACKGROUND, hb.x - 18.0f * Settings.scale, hb.y - 18.0f * Settings.scale, HIGHLIGHT_WIDTH, HIGHLIGHT_HEIGHT);
 
         sb.setColor(color);
-        sb.draw(COLOR, hb.x - 18.0f * Settings.scale, hb.y - 18.0f * Settings.scale);
+        sb.draw(COLOR, hb.x - 18.0f * Settings.scale, hb.y - 18.0f * Settings.scale, HIGHLIGHT_WIDTH, HIGHLIGHT_HEIGHT);
 
         if (showX)
-            sb.draw(X, hb.x - 18.0f * Settings.scale, hb.y - 18.0f * Settings.scale);
+            sb.draw(X, hb.x - 18.0f * Settings.scale, hb.y - 18.0f * Settings.scale, HIGHLIGHT_WIDTH, HIGHLIGHT_HEIGHT);
     }
 
     public void setVisible(boolean val) {

--- a/src/main/java/menu/Checkbox.java
+++ b/src/main/java/menu/Checkbox.java
@@ -20,8 +20,8 @@ public class Checkbox {
     private Hitbox hb;
     private Consumer<Checkbox> onToggle;
 
-    public static final float BUTTON_WIDTH = 32.0f;
-    public static final float BUTTON_HEIGHT = 32.0f;
+    public static final float BUTTON_WIDTH = 32.0f * Settings.scale;
+    public static final float BUTTON_HEIGHT = 32.0f * Settings.scale;
 
     private static final Texture CHECKBOX_DEFAULT = new Texture("images/checkbox/checkbox.png");
     private static final Texture CHECKBOX_CHECKED = new Texture("images/checkbox/checkbox_checked.png");
@@ -81,10 +81,10 @@ public class Checkbox {
         sb.setColor(Color.WHITE);
 
         if (checked) {
-            sb.draw(CHECKBOX_CHECKED, x, y);
+            sb.draw(CHECKBOX_CHECKED, x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
         }
         else {
-            sb.draw(CHECKBOX_DEFAULT, x, y);
+            sb.draw(CHECKBOX_DEFAULT, x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
         }
 
         hb.render(sb);

--- a/src/main/java/menu/ClearButton.java
+++ b/src/main/java/menu/ClearButton.java
@@ -19,8 +19,8 @@ public class ClearButton {
 
     private Hitbox hb;
 
-    private static final float BUTTON_WIDTH = 250.0f;
-    private static final float BUTTON_HEIGHT = 50.0f;
+    private static final float BUTTON_WIDTH = 250.0f * Settings.scale;
+    private static final float BUTTON_HEIGHT = 50.0f * Settings.scale;
 
     private static final Texture BUTTON_DEFAULT = new Texture("images/button/button_default.png");
     private static final Texture BUTTON_HOVER = new Texture("images/button/button_hover.png");
@@ -66,14 +66,14 @@ public class ClearButton {
 
         if (hb.hovered) {
             if (InputHelper.isMouseDown) {
-                sb.draw(BUTTON_CLICK, x, y);
+                sb.draw(BUTTON_CLICK, x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
             }
             else {
-                sb.draw(BUTTON_HOVER, x, y);
+                sb.draw(BUTTON_HOVER, x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
             }
         }
         else {
-            sb.draw(BUTTON_DEFAULT, x, y);
+            sb.draw(BUTTON_DEFAULT, x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
         }
 
         // text

--- a/src/main/java/menu/ColorPicker.java
+++ b/src/main/java/menu/ColorPicker.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.Hitbox;
 import utils.ClickWatcher;
 import utils.MiscUtils;
@@ -18,8 +19,8 @@ public class ColorPicker {
         private static final Texture TEX_FRAME = new Texture("images/colorpicker/color_picker_frame.png");
         private static final Texture TEX_X = new Texture("images/colorpicker/x.png");
 
-        public static final float TEX_WIDTH = 40.0f;
-        public static final float TEX_HEIGHT = 40.0f;
+        public static final float TEX_WIDTH = 40.0f * Settings.scale;
+        public static final float TEX_HEIGHT = 40.0f * Settings.scale;
 
         private Color color;
         private static final Color BORDER_COLOR_NOT_SELECTED = MyColors.GRAY_BORDER_COLOR;
@@ -79,18 +80,18 @@ public class ColorPicker {
 
             // Draw the color area
             sb.setColor(color);
-            sb.draw(TEX_COLOR, x, y);
+            sb.draw(TEX_COLOR, x, y, TEX_WIDTH, TEX_HEIGHT);
 
             if (selected)
                 sb.setColor(BORDER_COLOR_SELECTED);
             else
                 sb.setColor(BORDER_COLOR_NOT_SELECTED);
 
-            sb.draw(TEX_FRAME, x, y);
+            sb.draw(TEX_FRAME, x, y, TEX_WIDTH, TEX_HEIGHT);
 
             if (MiscUtils.isAltPressed()) {
                 sb.setColor(Color.WHITE);
-                sb.draw(TEX_X, x, y);
+                sb.draw(TEX_X, x, y, TEX_WIDTH, TEX_HEIGHT);
             }
 
         }
@@ -99,7 +100,7 @@ public class ColorPicker {
 //    public static final Color COLOR_PURPLE = new Color(0.914f, 0.478f, 0.937f, 0.8f);
 //    public static final Color COLOR_GREEN = new Color(0.0f, 1.0f, 0.0f, 0.8f);
 
-    private static final float PADDING = 7.0f;
+    private static final float PADDING = 7.0f * Settings.scale;
 
     private float x, y;
 

--- a/src/main/java/menu/HighlightMenu.java
+++ b/src/main/java/menu/HighlightMenu.java
@@ -20,17 +20,19 @@ public class HighlightMenu implements RenderSubscriber {
     public static HighlightMenu getInstance() { return HighlightMenuHolder.INSTANCE; }
 
     private static final Texture SCREEN = new Texture("images/highlight_menu.png");
-    private static final float SCREEN_X = 1486.0f;
-    private static final float SCREEN_Y = 67.0f;
+    public static final float SCREEN_WIDTH = 360.0f * Settings.scale;
+    public static final float SCREEN_HEIGHT = 245.0f * Settings.scale;
+    private static final float SCREEN_X = 1670.0f * Settings.xScale - SCREEN_WIDTH / 2;
+    private static final float SCREEN_Y = 67.0f * Settings.yScale;
 
-    private static final float CONTENT_X = 37.0f;
-    private static final float CHECKBOX_X = 230.0f;
+    private static final float CONTENT_X = 37.0f * Settings.scale;
+    private static final float CHECKBOX_X = 230.0f * Settings.scale;
 
-    private static final float TITLE_Y = 209.0f;
-    private static final float COLOR_PICKER_Y = 130.0f;
-    private static final float UNREACHABLE_Y = 112.0f;
-    private static final float BUTTON_Y = 28.0f;
-    private static final float CHECKBOX_Y = UNREACHABLE_Y - Checkbox.BUTTON_HEIGHT + 8.0f;
+    private static final float TITLE_Y = 209.0f * Settings.scale;
+    private static final float COLOR_PICKER_Y = 130.0f * Settings.scale;
+    private static final float UNREACHABLE_Y = 112.0f * Settings.scale;
+    private static final float BUTTON_Y = 28.0f * Settings.scale;
+    private static final float CHECKBOX_Y = UNREACHABLE_Y - Checkbox.BUTTON_HEIGHT + 8.0f * Settings.scale;
 
     private HighlightManager manager;
     //private LegendHelper legendHelper;
@@ -102,7 +104,7 @@ public class HighlightMenu implements RenderSubscriber {
 
         // background
         sb.setColor(Color.WHITE);
-        sb.draw(SCREEN, SCREEN_X, SCREEN_Y);
+        sb.draw(SCREEN, SCREEN_X, SCREEN_Y, SCREEN_WIDTH, SCREEN_HEIGHT);
 
         // title text
         FontHelper.renderFontLeftTopAligned(sb, FontHelper.tipBodyFont, "Highlight Menu", SCREEN_X + CONTENT_X, SCREEN_Y + TITLE_Y, Settings.GOLD_COLOR);


### PR DESCRIPTION
I added scaling support for other resolutions again, this time I did y-scaling as well so it should work for any resolution (although I haven't been able to test heights greater than 1080p to be certain). The x-position of the menu has been shifted by a few pixels on 1920x1080, it's now set to be centred with the basegame legend, which I'm guessing is what you were going for anyways. Images below are, in order, 2560x1080 (21:9), 1024x768 (4:3), 1920x1080.

![20210717004941_1](https://user-images.githubusercontent.com/9139051/126018942-00f1517c-dd02-4b8d-b20c-b94b70c49a08.jpg)
![20210717005451_1](https://user-images.githubusercontent.com/9139051/126018949-d76cd2d7-e07d-4440-a7ca-9224d7471b28.jpg)
![20210717005632_1](https://user-images.githubusercontent.com/9139051/126018950-c75e262d-f40f-461e-92ce-e5b935dca45b.jpg)